### PR TITLE
Updated PropTypes import

### DIFF
--- a/src/react-zoomy.js
+++ b/src/react-zoomy.js
@@ -1,5 +1,6 @@
 // export default  4;
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Motion, spring } from 'react-motion';
 import CssToMatrix from 'css-to-matrix';


### PR DESCRIPTION
The component was throwing an error because react changed the way to import PropTypes.

Awesome work and tutorials btw! Thanks!