### PR TITLE
Workaround for 'Cannot read property 'string''

### DIFF
--- a/lib/react-zoomy.js
+++ b/lib/react-zoomy.js
@@ -291,15 +291,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return ReactZoomy;
 	}(_react.Component);
 	
-	ReactZoomy.propTypes = {
-	  imageUrl: _react.PropTypes.string.isRequired,
-	  renderThumbnail: _react.PropTypes.func.isRequired,
-	  renderCursor: _react.PropTypes.func,
-	  renderLoadingElement: _react.PropTypes.func,
-	  imageContainerProps: _react.PropTypes.object,
-	  imageProps: _react.PropTypes.object,
-	  scale: _react.PropTypes.array
-	};
 	ReactZoomy.defaultProps = {
 	  scale: [1, 1]
 	};


### PR DESCRIPTION
Removed static property ReactZoomy.propTypes